### PR TITLE
The DPPs menu item has been hidden from the sidebar.

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -66,6 +66,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       title: t('menu.dpps'),
       href: "/dashboard/dpps",
       icon: QrCode,
+      show: false,
     },
     {
       title: t('menu.suppliers'),


### PR DESCRIPTION
DPPs menü öğesi, sidebar'dan `show: false` ile gizlendi. 