### PR TITLE
Fix/translate document certification types

### DIFF
--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -2413,7 +2413,8 @@
       "typePlaceholder": "Select document type",
       "fileLabel": "File",
       "filePlaceholder": "Select or drag a file here",
-      "submit": "Upload"
+      "submit": "Upload",
+      "companyNotFoundError": "Company information not found. Please complete the company registration first."
     }
   },
   "admin": {

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -9,6 +9,19 @@
     "verifyProducts": "Verify Products",
     "signIn": "Sign In"
   },
+  "aiGuidance": {
+    "guidanceUnavailable": "Guidance unavailable",
+    "tryAgain": "Try again",
+    "aiDocumentGuidance": "AI Document Guidance",
+    "recommendedDocumentsFor":"Recommended Documents For",
+    "requiredDocuments":"Required Documents",
+    "required":"Required",
+    "examples":"Examples",
+    "optionalDocuments":"Optional Documents",
+    "optional":"Optional",
+    "generalNotes":"General Notes",
+    "complianceRequirements":"Compliance Requirements"
+  },
   "registration": {
     "steps": {
       "documents": {
@@ -1637,6 +1650,49 @@
   "productManagement": {
     "title": "Product Management",
     "description": "Manage and track all your products",
+    "edit":{
+      "editProduct":"Edit Product",
+      "productName":"Product Name",
+      "model":"Model",
+      "productType":"Product Type",
+      "productImages":"Product Images",
+      "addNewImage":"Add New Image",
+      "productDocuments":"Product Documents",
+      "pending":"Pending",
+      "rejected":"Rejected",
+      "approved":"Approved",
+      "type":"Type",
+      "uploadDate":"Upload Date",
+      "version":"Version",
+      "download":"Download",
+      "delete":"Delete",
+      "cancel":"Cancel",
+      "saveChanges":"Save Changes",
+      "rejectionReason":"Rejection Reason",
+      "addNewDocument":"Add New Document",
+      "back":"Back",
+      "primary":"Primary",
+      "addNewDocumentDescription":"Add new document description",
+      "documentFile":"Document File",
+      "documentType":"Document Type",
+      "selectDocumentType":"Select Document Type",
+      "technicalDocumentation":"Technical Documentation",
+      "testReports":"Test Reports",
+      "complianceDocuments":"Compliance Documents",
+      "certificates":"Certificates",
+      "other":"Other",
+      "uploadDocument":"Upload Document",
+      "deleteDocument":"Delete Document",
+      "deleteDocumentConfirmation":"Are you sure you want to delete this document?",
+      "uploading":"Uploading...",
+      "success":"Success",
+      "imageUploadedSuccess":"Image uploaded successfully",
+      "setAsPrimary":"Set as Primary",
+      "primaryImageUpdatedSuccess":"Primary image updated successfully",
+      "imageDeletedSuccess":"Image deleted successfully",
+      "saving":"Saving...",
+      "productUpdatedSuccess":"Product updated successfully"
+    },
     "materials": {
       "title": "Materials",
       "description": "Manage and track all your materials",
@@ -1777,6 +1833,7 @@
       }
     },
     "list": {
+      "more": "more",
       "title": "Product List",
       "description": "View and manage your products",
       "loading": "Loading products...",
@@ -1817,9 +1874,10 @@
       "showing": "Showing {start} to {end} of {total} products"
     },
     "status": {
-      "draft": "Draft",
-      "published": "Published",
-      "archived": "Archived"
+      "archived": "Archived",
+      "approved": "Approved",
+      "rejected": "Rejected",
+      "pending": "Pending"
     },
     "delete": {
       "title": "Delete Product",
@@ -1972,6 +2030,23 @@
     "title": "Document Management",
     "description": "Manage your company documents and certificates",
     "backToList": "Back to List",
+    "history": {
+      "documentHistory": "Document History",
+      "documentUploaded": "Document uploaded",
+      "initialDocumentUpload": "Initial document upload",
+      "statusChanged": "Status changed",
+      "documentStatusUpdatedToPending": "Document status updated to pending",
+      "version": "Version",
+      "system": "System",
+      "admin": "Admin",
+      "back": "Back",
+      "error": "Error",
+      "failedToLoadHistory": "Failed to load history",
+      "noHistoryFound": "No history found",
+      "noHistoryDescription": "No history found for this document.",
+      "approved": "Approved",
+      "rejected": "Rejected"
+    },
     "repository": {
       "title": "Document Repository",
       "noDocumentsFound": "No documents found",
@@ -2413,8 +2488,7 @@
       "typePlaceholder": "Select document type",
       "fileLabel": "File",
       "filePlaceholder": "Select or drag a file here",
-      "submit": "Upload",
-      "companyNotFoundError": "Company information not found. Please complete the company registration first."
+      "submit": "Upload"
     }
   },
   "admin": {

--- a/app/i18n/locales/tr.json
+++ b/app/i18n/locales/tr.json
@@ -5,6 +5,19 @@
     "verifyProducts": "Ürün Doğrula",
     "signIn": "Giriş Yap"
   },
+  "aiGuidance": {
+    "guidanceUnavailable": "AI Rehberliği Alınamadı",
+    "tryAgain": "Tekrar Dene",
+    "aiDocumentGuidance": "AI Belge Rehberliği",
+    "recommendedDocumentsFor":"Önerilen Belgeler",
+    "requiredDocuments":"Zorunlu Belgeler",
+    "required":"Zorunlu",
+    "examples":"Örnekler",
+    "optionalDocuments":"İsteğe Bağlı Belgeler",
+    "optional":"Opsiyonel",
+    "generalNotes":"Genel Notlar",
+    "complianceRequirements":"Uyumluluk Gereksinimleri"
+  },
   "registration": {
     "steps": {
       "documents": {
@@ -2568,6 +2581,49 @@
     "noProducts": "Ürün bulunamadı",
     "editProduct": "Ürünü Düzenle",
     "deleteProduct": "Ürünü Sil",
+    "edit":{
+      "editProduct":"Ürünü Düzenle",
+      "productName":"Ürün Adı",
+      "model":"Model",
+      "productType":"Ürün Tipi",
+      "productImages":"Ürün Görselleri",
+      "addNewImage":"Yeni Görsel Ekle",
+      "productDocuments":"Ürün Belgeleri",
+      "pending":"Beklemede",
+      "rejected":"Reddedildi",
+      "approved":"Onaylandı",
+      "type":"Tip",
+      "uploadDate":"Yükleme Tarihi",
+      "version":"Versiyon",
+      "download":"İndir",
+      "delete":"Sil",
+      "cancel":"İptal",
+      "saveChanges":"Değişiklikleri Kaydet",
+      "rejectionReason":"Reddedilme Sebebi",
+      "addNewDocument":"Yeni Belgeler Ekle",
+      "back":"Geri",
+      "primary":"Öne Çıkar",
+      "addNewDocumentDescription":"Yeni belge açıklaması ekleyin",
+      "documentFile":"Belge Dosyası",
+      "documentType":"Belge Tipi",
+      "selectDocumentType":"Belge Tipi Seçin",
+      "technicalDocumentation":"Teknik Belgeler",
+      "testReports":"Test Raporları",
+      "complianceDocuments":"Uyum Belgeleri",
+      "certificates":"Sertifikalar",
+      "other":"Diğer",
+      "uploadDocument":"Belge Yükle",
+      "deleteDocument":"Belge Sil",
+      "deleteDocumentConfirmation":"Bu belgeyi silmek istediğinizden emin misiniz?",
+      "uploading":"Yükleniyor...",
+      "success":"Başarılı",
+      "imageUploadedSuccess":"Görsel başarıyla yüklendi",
+      "setAsPrimary":"Öne Çıkar",
+      "primaryImageUpdatedSuccess":"Öne çıkarılan görsel başarıyla güncellendi",
+      "imageDeletedSuccess":"Görsel başarıyla silindi",
+      "saving":"Kaydediliyor...",
+      "productUpdatedSuccess":"Ürün başarıyla güncellendi"
+    },
     "materials": {
       "title": "Materyaller",
       "description": "Materyallerinizi yönetin ve takip edin",
@@ -2649,6 +2705,12 @@
         "add": "Özellik Ekle"
       }
     },
+    "status": {
+      "approved": "Onaylandı",
+      "rejected": "Reddedildi",
+      "pending": "Beklemede",
+      "archived": "Arşivlendi"
+    },
     "filters": {
       "type": {
         "label": "Ürün Tipi",
@@ -2687,6 +2749,7 @@
       "openMenu": "Menüyü Aç"
     },
     "list": {
+      "more": "daha fazla",
       "title": "Ürün Listesi",
       "description": "Tüm ürünlerinizi görüntüleyin ve yönetin",
       "loading": "Ürünler yükleniyor...",
@@ -2818,6 +2881,23 @@
     "title": "Belge Yönetimi",
     "description": "Belge yüklemelerini inceleyin ve yönetin",
     "backToList": "Listeye Dön",
+    "history": {
+      "documentHistory": "Belge Geçmişi",
+      "documentUploaded": "Belge yüklendi",
+      "initialDocumentUpload": "Başlangıç belgesi yüklendi",
+      "statusChanged": "Durum değişti",
+      "documentStatusUpdatedToPending": "Belge durumu beklemede olarak güncellendi",
+      "version": "Versiyon",
+      "system": "Sistem",
+      "admin": "Yönetici",
+      "back": "Geri",
+      "error": "Hata",
+      "failedToLoadHistory": "Belge geçmişi yüklenemedi",
+      "noHistoryFound": "Geçmiş Bulunamadı",
+      "noHistoryDescription": "Bu belgenin geçmiş kayıtları bulunmuyor.",
+      "approved": "Onaylandı",
+      "rejected": "Reddedildi"
+    },
     "documentTypes": {
       "testReports": "Test Raporları",
       "technicalDocumentation": "Teknik Dokümantasyon",

--- a/app/i18n/locales/tr.json
+++ b/app/i18n/locales/tr.json
@@ -3698,7 +3698,8 @@
       "typePlaceholder": "Döküman tipini seçin",
       "fileLabel": "Dosya Seçin",
       "filePlaceholder": "Dosyayı seçin",
-      "submit": "Yükle"
+      "submit": "Yükle",
+      "companyNotFoundError": "Şirket bilgisi bulunamadı. Lütfen önce şirket kaydını tamamlayın."
     },
     "filters": {
       "all": "Tümü",

--- a/components/dashboard/certifications/certification-list.tsx
+++ b/components/dashboard/certifications/certification-list.tsx
@@ -150,24 +150,7 @@ export function CertificationList({ filters }: CertificationListProps) {
   };
 
   const getDocumentType = (type: string) => {
-    switch (type) {
-      case 'quality_certificate':
-        return 'Kalite Sertifikası';
-      case 'safety_certificate':
-        return 'Güvenlik Sertifikası';
-      case 'environmental_certificate':
-        return 'Çevre Sertifikası';
-      case 'iso_certificate':
-        return 'ISO Sertifikası';
-      case 'export_certificate':
-        return 'İhracat Sertifikası';
-      case 'production_permit':
-        return 'Üretim İzni';
-      case 'activity_permit':
-        return 'Faaliyet İzni';
-      default:
-        return type;
-    }
+    return t(`types.${type}`, { defaultValue: type });
   };
 
   if (isLoading) {

--- a/components/dashboard/documents/company-document-list.tsx
+++ b/components/dashboard/documents/company-document-list.tsx
@@ -264,7 +264,7 @@ export function CompanyDocumentList() {
                     </div>
                   </div>
                 </TableCell>
-                <TableCell>{doc.type}</TableCell>
+                <TableCell>{t(`documents.types.${doc.type}`, { defaultValue: doc.type })}</TableCell>
                 <TableCell>
                   <Badge
                     variant={getStatusVariant(doc.status)}

--- a/components/dashboard/documents/document-history.tsx
+++ b/components/dashboard/documents/document-history.tsx
@@ -4,6 +4,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { ArrowLeft, History, CheckCircle, XCircle, Clock, AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -28,6 +29,7 @@ export function DocumentHistory({ documentId }: DocumentHistoryProps) {
   const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
   const supabase = createClientComponentClient();
+  const t = useTranslations("documentManagement.history");
 
   useEffect(() => {
     async function fetchHistory() {
@@ -37,18 +39,18 @@ export function DocumentHistory({ documentId }: DocumentHistoryProps) {
         const mockHistory: HistoryEntry[] = [
           {
             id: "1",
-            action: "Document Uploaded",
-            user: "System",
+            action: t("documentUploaded"),
+            user: t("system"),
             timestamp: new Date().toISOString(),
-            details: "Initial document upload",
+            details: t("initialDocumentUpload"),
             version: "1.0",
           },
           {
             id: "2",
-            action: "Status Changed",
-            user: "Admin",
+            action: t("statusChanged"),
+            user: t("admin"),
             timestamp: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
-            details: "Document status updated to PENDING",
+            details: t("documentStatusUpdatedToPending"),
             version: "1.0",
           },
         ];
@@ -57,8 +59,8 @@ export function DocumentHistory({ documentId }: DocumentHistoryProps) {
       } catch (error) {
         console.error("Error fetching document history:", error);
         toast({
-          title: "Error",
-          description: "Failed to load document history",
+          title: t("error"),
+          description: t("failedToLoadHistory"),
           variant: "destructive",
         });
       } finally {
@@ -71,13 +73,13 @@ export function DocumentHistory({ documentId }: DocumentHistoryProps) {
 
   const getActionIcon = (action: string) => {
     switch (action.toLowerCase()) {
-      case "document uploaded":
+      case t("documentUploaded").toLowerCase():
         return <History className="h-4 w-4" />;
-      case "status changed":
+      case t("statusChanged").toLowerCase():
         return <AlertTriangle className="h-4 w-4" />;
-      case "approved":
+      case t("approved").toLowerCase():
         return <CheckCircle className="h-4 w-4" />;
-      case "rejected":
+      case t("rejected").toLowerCase():
         return <XCircle className="h-4 w-4" />;
       default:
         return <Clock className="h-4 w-4" />;
@@ -88,7 +90,7 @@ export function DocumentHistory({ documentId }: DocumentHistoryProps) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Document History</CardTitle>
+          <CardTitle>{t("documentHistory")}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -114,19 +116,19 @@ export function DocumentHistory({ documentId }: DocumentHistoryProps) {
           <Button variant="ghost" size="icon" asChild>
             <Link href="/dashboard/documents">
               <ArrowLeft className="h-4 w-4" />
-              <span className="sr-only">Back</span>
+              <span className="sr-only">{t("back")}</span>
             </Link>
           </Button>
-          <CardTitle>Document History</CardTitle>
+          <CardTitle>{t("documentHistory")}</CardTitle>
         </div>
       </CardHeader>
       <CardContent>
         {history.length === 0 ? (
           <div className="text-center py-8">
             <History className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-lg font-medium mb-2">No History Found</h3>
+            <h3 className="text-lg font-medium mb-2">{t("noHistoryFound")}</h3>
             <p className="text-muted-foreground">
-              This document has no history entries.
+              {t("noHistoryDescription")}
             </p>
           </div>
         ) : (
@@ -140,7 +142,7 @@ export function DocumentHistory({ documentId }: DocumentHistoryProps) {
                   <div className="flex items-center justify-between">
                     <h4 className="font-medium">{entry.action}</h4>
                     <Badge variant="outline">
-                      v{entry.version}
+                      {t("version")} {entry.version}
                     </Badge>
                   </div>
                   <p className="text-sm text-muted-foreground mt-1">{entry.details}</p>

--- a/components/dashboard/products/DocumentGuidanceCard.tsx
+++ b/components/dashboard/products/DocumentGuidanceCard.tsx
@@ -28,7 +28,7 @@ export function DocumentGuidanceCard({
   productTypeLabel,
   subcategoryLabel,
 }: DocumentGuidanceCardProps) {
-  const t = useTranslations();
+  const t = useTranslations("aiGuidance");
 
   if (isLoading) {
     return (
@@ -54,7 +54,7 @@ export function DocumentGuidanceCard({
         <CardHeader>
           <div className="flex items-center gap-2">
             <AlertCircle className="h-5 w-5 text-red-600" />
-            <CardTitle className="text-red-800">AI Rehberliği Alınamadı</CardTitle>
+            <CardTitle className="text-red-800">{t("guidanceUnavailable")}</CardTitle>
           </div>
         </CardHeader>
         <CardContent>
@@ -69,7 +69,7 @@ export function DocumentGuidanceCard({
             className="mt-4"
           >
             <RefreshCw className="h-4 w-4 mr-2" />
-            Tekrar Dene
+            {t("tryAgain")}
           </Button>
         </CardContent>
       </Card>
@@ -86,7 +86,7 @@ export function DocumentGuidanceCard({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Sparkles className="h-5 w-5 text-blue-600" />
-            <CardTitle className="text-blue-800">AI Document Guidance</CardTitle>
+            <CardTitle className="text-blue-800">{t("aiDocumentGuidance")}</CardTitle>
           </div>
           <Button
             variant="ghost"
@@ -98,7 +98,7 @@ export function DocumentGuidanceCard({
           </Button>
         </div>
         <CardDescription className="text-blue-700">
-          Recommended documents for {productTypeLabel || guidance.productType} - {subcategoryLabel || guidance.subcategory}
+          {t("recommendedDocumentsFor")} {productTypeLabel || guidance.productType} - {subcategoryLabel || guidance.subcategory}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -107,7 +107,7 @@ export function DocumentGuidanceCard({
           <div>
             <h4 className="font-semibold text-green-800 mb-3 flex items-center gap-2">
               <CheckCircle className="h-4 w-4" />
-              Required Documents
+              {t("requiredDocuments")}
             </h4>
             <div className="space-y-3">
               {guidance.requiredDocuments.map((doc, index) => (
@@ -115,13 +115,13 @@ export function DocumentGuidanceCard({
                   <div className="flex items-start justify-between mb-2">
                     <h5 className="font-medium text-green-800">{doc.label}</h5>
                     <Badge variant="default" className="bg-green-100 text-green-800">
-                      Required
+                      {t("required")}
                     </Badge>
                   </div>
                   <p className="text-sm text-gray-600 mb-2">{doc.description}</p>
                   {doc.examples.length > 0 && (
                     <div>
-                      <p className="text-xs font-medium text-gray-500 mb-1">Examples:</p>
+                      <p className="text-xs font-medium text-gray-500 mb-1">{t("examples")}:</p>
                       <div className="flex flex-wrap gap-1">
                         {doc.examples.map((example, idx) => (
                           <Badge key={idx} variant="secondary" className="text-xs">
@@ -142,7 +142,7 @@ export function DocumentGuidanceCard({
           <div>
             <h4 className="font-semibold text-blue-800 mb-3 flex items-center gap-2">
               <Info className="h-4 w-4" />
-              Optional Documents
+              {t("optionalDocuments")}
             </h4>
             <div className="space-y-3">
               {guidance.optionalDocuments.map((doc, index) => (
@@ -150,13 +150,13 @@ export function DocumentGuidanceCard({
                   <div className="flex items-start justify-between mb-2">
                     <h5 className="font-medium text-blue-800">{doc.label}</h5>
                     <Badge variant="outline" className="text-blue-600">
-                      Optional
+                      {t("optional")}
                     </Badge>
                   </div>
                   <p className="text-sm text-gray-600 mb-2">{doc.description}</p>
                   {doc.examples.length > 0 && (
                     <div>
-                      <p className="text-xs font-medium text-gray-500 mb-1">Examples:</p>
+                      <p className="text-xs font-medium text-gray-500 mb-1">{t("examples")}:</p>
                       <div className="flex flex-wrap gap-1">
                         {doc.examples.map((example, idx) => (
                           <Badge key={idx} variant="secondary" className="text-xs">
@@ -177,7 +177,7 @@ export function DocumentGuidanceCard({
           <Collapsible>
             <CollapsibleTrigger asChild>
               <Button variant="ghost" className="w-full justify-between p-0 h-auto">
-                <span className="text-sm font-medium text-gray-700">General Notes</span>
+                <span className="text-sm font-medium text-gray-700">{t("generalNotes")}</span>
                 <Info className="h-4 w-4" />
               </Button>
             </CollapsibleTrigger>
@@ -194,7 +194,7 @@ export function DocumentGuidanceCard({
           <Collapsible>
             <CollapsibleTrigger asChild>
               <Button variant="ghost" className="w-full justify-between p-0 h-auto">
-                <span className="text-sm font-medium text-gray-700">Compliance Requirements</span>
+                <span className="text-sm font-medium text-gray-700">{t("complianceRequirements")}</span>
                 <AlertCircle className="h-4 w-4" />
               </Button>
             </CollapsibleTrigger>

--- a/components/dashboard/products/product-edit.tsx
+++ b/components/dashboard/products/product-edit.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, AlertCircle, Upload, FileText, Download, Trash2, Plus } from
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-
+import { useTranslations } from "next-intl";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -38,25 +38,25 @@ interface ProductEditProps {
   reuploadDocumentId?: string;
 }
 
-const documentTypeLabels: Record<string, string> = {
-  quality_cert: "Quality Certificate",
-  safety_cert: "Safety Certificate",
-  test_reports: "Test Reports",
-  technical_docs: "Technical Documentation",
-  compliance_docs: "Compliance Documents",
-  certificates: "Certificates",
-  other: "Other"
-};
+const documentTypeLabels = (t: any): Record<string, string> => ({
+  quality_cert: t("qualityCertificate"),
+  safety_cert: t("safetyCertificate"),
+  test_reports: t("testReports"),
+  technical_docs: t("technicalDocumentation"),
+  compliance_docs: t("complianceDocuments"),
+  certificates: t("certificates"),
+  other: t("other")
+});
 
 // Belge türünü gösterme fonksiyonu - AI türlerini destekler
-const getDocumentTypeLabel = (doc: any) => {
+const getDocumentTypeLabel = (doc: any, t: any) => {
   // Eğer originalType varsa (AI'dan gelen), onu göster
   if (doc.originalType) {
     return doc.originalType;
   }
   
   // Standart türler için label kullan
-  return documentTypeLabels[doc.type] || doc.type;
+  return documentTypeLabels(t)[doc.type] || doc.type;
 };
 
 export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps) {
@@ -67,6 +67,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
   const [isSaving, setIsSaving] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [isDeleting, setIsDeleting] = useState<string | null>(null);
+  const t = useTranslations("productManagement.edit");
   const [newDocument, setNewDocument] = useState<{
     file: File | null;
     name: string;
@@ -154,8 +155,8 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
       } catch (error) {
         console.error("Error fetching product:", error);
         toast({
-          title: "Error",
-          description: "Failed to load product details",
+          title: t("error"),
+          description: t("failedToLoadProduct"),
           variant: "destructive",
         });
       } finally {
@@ -210,14 +211,14 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
       setAllDocuments(documents);
       
       toast({
-        title: "Success",
-        description: "Document uploaded successfully",
+        title: t("success"),
+        description: t("documentUploadedSuccess"),
       });
     } catch (error) {
       console.error("Error uploading document:", error);
       toast({
-        title: "Error",
-        description: "Failed to upload document",
+        title: t("error"),
+        description: t("failedToUploadDocument"),
         variant: "destructive",
       });
     } finally {
@@ -248,14 +249,14 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
       setAllDocuments(prev => prev.filter(doc => doc.id !== documentToDelete.id));
 
       toast({
-        title: "Success",
-        description: "Document deleted successfully",
+        title: t("success"),
+        description: t("documentDeletedSuccess"),
       });
     } catch (error) {
       console.error("Error deleting document:", error);
       toast({
-        title: "Error",
-        description: "Failed to delete document",
+        title: t("error"),
+        description: t("failedToDeleteDocument"),
         variant: "destructive",
       });
     } finally {
@@ -290,14 +291,14 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
       setShowAddDialog(false);
 
       toast({
-        title: "Success",
-        description: "Document added successfully",
+        title: t("success"),
+        description: t("documentAddedSuccess"),
       });
     } catch (error) {
       console.error("Error adding document:", error);
       toast({
-        title: "Error",
-        description: "Failed to add document",
+        title: t("error"),
+        description: t("failedToAddDocument"),
         variant: "destructive",
       });
     } finally {
@@ -323,16 +324,16 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
       if (error) throw error;
 
       toast({
-        title: "Success",
-        description: "Product updated successfully",
+        title: t("success"),
+        description: t("productUpdatedSuccess"),
       });
 
       router.push("/dashboard/products");
     } catch (error) {
       console.error("Error updating product:", error);
       toast({
-        title: "Error",
-        description: "Failed to update product",
+        title: t("error"),
+        description: t("failedToUpdateProduct"),
         variant: "destructive",
       });
     } finally {
@@ -344,9 +345,9 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
     if (!status) return null;
     
     const statusConfig = {
-      pending: { variant: "secondary" as const, text: "Pending" },
-      approved: { variant: "default" as const, text: "Approved" },
-      rejected: { variant: "destructive" as const, text: "Rejected" },
+      pending: { variant: "secondary" as const, text: t("pending") },
+      approved: { variant: "default" as const, text: t("approved") },
+      rejected: { variant: "destructive" as const, text: t("rejected") },
     };
 
     const config = statusConfig[status as keyof typeof statusConfig] || statusConfig.pending;
@@ -398,14 +399,14 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
       setNewImage(null);
 
       toast({
-        title: "Success",
-        description: "Image uploaded successfully",
+        title: t("success"),
+        description: t("imageUploadedSuccess"),
       });
     } catch (error) {
       console.error("Error uploading image:", error);
       toast({
-        title: "Error",
-        description: "Failed to upload image",
+        title: t("error"),
+        description: t("failedToUploadImage"),
         variant: "destructive",
       });
     } finally {
@@ -427,14 +428,14 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
       setProduct(prev => prev ? { ...prev, images: updatedImages } : null);
 
       toast({
-        title: "Success",
-        description: "Image deleted successfully",
+        title: t("success"),
+        description: t("imageDeletedSuccess"),
       });
     } catch (error) {
       console.error("Error deleting image:", error);
       toast({
-        title: "Error",
-        description: "Failed to delete image",
+        title: t("error"),
+        description: t("failedToDeleteImage"),
         variant: "destructive",
       });
     }
@@ -458,13 +459,13 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
 
       setProduct(prev => prev ? { ...prev, images: updatedImages } : null);
       toast({
-        title: "Success",
-        description: "Primary image updated successfully",
+        title: t("success"),
+        description: t("primaryImageUpdatedSuccess"),
       });
     } catch (error) {
       toast({
-        title: "Error",
-        description: "Failed to update primary image",
+        title: t("error"),
+        description: t("failedToUpdatePrimaryImage"),
         variant: "destructive",
       });
     }
@@ -474,7 +475,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Edit Product</CardTitle>
+          <CardTitle>{t("editProduct")}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -494,12 +495,12 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
     return (
       <Card>
         <CardContent className="flex flex-col items-center justify-center py-12">
-          <h2 className="text-xl font-semibold mb-2">Product Not Found</h2>
+          <h2 className="text-xl font-semibold mb-2">{t("productNotFound")}</h2>
           <p className="text-muted-foreground mb-4">
-            The requested product could not be found.
+            {t("productNotFoundDescription")}
           </p>
           <Button asChild>
-            <Link href="/dashboard/products">Back to Products</Link>
+            <Link href="/dashboard/products">{t("backToProducts")}</Link>
           </Button>
         </CardContent>
       </Card>
@@ -514,10 +515,10 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
             <Button variant="ghost" size="icon" asChild>
               <Link href="/dashboard/products">
                 <ArrowLeft className="h-4 w-4" />
-                <span className="sr-only">Back</span>
+                <span className="sr-only">{t("back")}</span>
               </Link>
             </Button>
-            <CardTitle>Edit Product</CardTitle>
+            <CardTitle>{t("editProduct")}</CardTitle>
           </div>
         </CardHeader>
         <CardContent>
@@ -530,11 +531,11 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
                 return (
                   <Alert variant="destructive">
                     <AlertCircle className="h-4 w-4" />
-                    <AlertTitle>Product Rejected</AlertTitle>
+                    <AlertTitle>{t("productRejected")}</AlertTitle>
                     <AlertDescription>
                       <div className="mt-2">
-                        <p><strong>Rejection Reason:</strong> {lastHistory.reason.replace("Rejected: ", "")}</p>
-                        <p><strong>Rejection Date:</strong> {new Date(lastHistory.timestamp).toLocaleDateString()}</p>
+                        <p><strong>{t("rejectionReason")}:</strong> {lastHistory.reason.replace("Rejected: ", "")}</p>
+                        <p><strong>{t("rejectionDate")}:</strong> {new Date(lastHistory.timestamp).toLocaleDateString()}</p>
                       </div>
                     </AlertDescription>
                   </Alert>
@@ -547,20 +548,20 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
           {rejectedDocument && (
             <Alert variant="destructive" key="rejected-document-alert">
               <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Document Rejected</AlertTitle>
+              <AlertTitle>{t("documentRejected")}</AlertTitle>
               <AlertDescription>
                 <div className="mt-2">
-                  <p key="doc-name"><strong>Document:</strong> {rejectedDocument.name}</p>
-                  <p key="doc-type"><strong>Type:</strong> {getDocumentTypeLabel(rejectedDocument)}</p>
-                  <p key="doc-reason"><strong>Rejection Reason:</strong> {rejectedDocument.rejection_reason}</p>
-                  <p key="doc-date"><strong>Rejection Date:</strong> {rejectedDocument.uploadedAt ? new Date(rejectedDocument.uploadedAt).toLocaleDateString() : "N/A"}</p>
+                  <p key="doc-name"><strong>{t("document")}:</strong> {rejectedDocument.name}</p>
+                  <p key="doc-type"><strong>{t("type")}:</strong> {getDocumentTypeLabel(rejectedDocument, t)}</p>
+                  <p key="doc-reason"><strong>{t("rejectionReason")}:</strong> {rejectedDocument.rejection_reason}</p>
+                  <p key="doc-date"><strong>{t("rejectionDate")}:</strong> {rejectedDocument.uploadedAt ? new Date(rejectedDocument.uploadedAt).toLocaleDateString() : t("notAvailable")}</p>
                 </div>
               </AlertDescription>
             </Alert>
           )}
           
           <div className="space-y-2">
-            <Label htmlFor="name">Product Name</Label>
+            <Label htmlFor="name">{t("productName")}</Label>
             <Input 
               id="name" 
               value={formData.name} 
@@ -568,7 +569,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="model">Model</Label>
+            <Label htmlFor="model">{t("model")}</Label>
             <Input 
               id="model" 
               value={formData.model} 
@@ -576,7 +577,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="type">Product Type</Label>
+            <Label htmlFor="type">{t("productType")}</Label>
             <Input 
               id="product_type" 
               value={getFullProductTypeDisplay()} 
@@ -588,7 +589,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
           
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold">Product Images</h3>
+              <h3 className="text-lg font-semibold">{t("productImages")}</h3>
               <div className="flex items-center gap-2">
                 <Input
                   type="file"
@@ -609,11 +610,11 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
                   disabled={isUploadingImage}
                 >
                   {isUploadingImage ? (
-                    "Uploading..."
+                    t("uploading")
                   ) : (
                     <>
                       <Upload className="h-4 w-4 mr-2" />
-                      Add New Image
+                      {t("addNewImage")}
                     </>
                   )}
                 </Button>
@@ -636,7 +637,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
                         onClick={() => handleSetPrimaryImage(image.url)}
                         disabled={image.is_primary}
                       >
-                        {image.is_primary ? "Primary" : "Set as Primary"}
+                        {image.is_primary ? t("primary") : t("setAsPrimary")}
                       </Button>
                       <Button
                         size="sm"
@@ -656,24 +657,24 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
           
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold">Product Documents</h3>
+              <h3 className="text-lg font-semibold">{t("productDocuments")}</h3>
               <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
                 <DialogTrigger asChild>
                   <Button size="sm">
                     <Plus className="h-4 w-4 mr-2" />
-                    Add New Document
+                    {t("addNewDocument")}
                   </Button>
                 </DialogTrigger>
                 <DialogContent>
                   <DialogHeader>
-                    <DialogTitle>Add New Document</DialogTitle>
+                    <DialogTitle>{t("addNewDocument")}</DialogTitle>
                     <DialogDescription>
-                      Upload a new document for this product.
+                      {t("addNewDocumentDescription")}
                     </DialogDescription>
                   </DialogHeader>
                   <div className="space-y-4 py-4">
                     <div className="space-y-2">
-                      <Label htmlFor="document-file">Document File</Label>
+                      <Label htmlFor="document-file">{t("documentFile")}</Label>
                       <Input
                         id="document-file"
                         type="file"
@@ -681,35 +682,35 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
                       />
                       {newDocument.file && (
                         <p className="text-sm text-muted-foreground">
-                          Selected: {newDocument.name}
+                          {t("selected")}: {newDocument.name}
                         </p>
                       )}
                     </div>
                     <div className="space-y-2">
-                      <Label htmlFor="document-type">Document Type</Label>
+                      <Label htmlFor="document-type">{t("documentType")}</Label>
                       <Select
                         value={newDocument.type}
                         onValueChange={handleDocumentTypeChange}
                       >
                         <SelectTrigger>
-                          <SelectValue placeholder="Select document type" />
+                          <SelectValue placeholder={t("selectDocumentType")} />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="technical_docs">Technical Documentation</SelectItem>
-                          <SelectItem value="test_reports">Test Reports</SelectItem>
-                          <SelectItem value="compliance_docs">Compliance Documents</SelectItem>
-                          <SelectItem value="certificates">Certificates</SelectItem>
-                          <SelectItem value="other">Other</SelectItem>
+                          <SelectItem value="technical_docs">{t("technicalDocumentation")}</SelectItem>
+                          <SelectItem value="test_reports">{t("testReports")}</SelectItem>
+                          <SelectItem value="compliance_docs">{t("complianceDocuments")}</SelectItem>
+                          <SelectItem value="certificates">{t("certificates")}</SelectItem>
+                          <SelectItem value="other">{t("other")}</SelectItem>
                         </SelectContent>
                       </Select>
                     </div>
                   </div>
                   <DialogFooter>
                     <Button variant="outline" onClick={() => setShowAddDialog(false)}>
-                      Cancel
+                      {t("cancel")}
                     </Button>
                     <Button onClick={handleAddNewDocument} disabled={isUploading || !newDocument.file}>
-                      {isUploading ? "Uploading..." : "Upload Document"}
+                      {isUploading ? t("uploading") : t("uploadDocument")}
                     </Button>
                   </DialogFooter>
                 </DialogContent>
@@ -718,7 +719,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
             
             {allDocuments.length === 0 ? (
               <div className="text-center py-6 text-muted-foreground">
-                No documents found for this product.
+                {t("noDocumentsFound")}
               </div>
             ) : (
               <div className="space-y-4">
@@ -734,7 +735,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
                         <Button variant="ghost" size="sm" asChild>
                           <Link href={doc.url || "#"}>
                             <Download className="h-4 w-4 mr-1" />
-                            Download
+                            {t("download")}
                           </Link>
                         </Button>
                         <Button 
@@ -744,30 +745,30 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
                           disabled={isDeleting === doc.id}
                         >
                           <Trash2 className="h-4 w-4 mr-1" />
-                          {isDeleting === doc.id ? "Deleting..." : "Delete"}
+                          {isDeleting === doc.id ? t("deleting") : t("delete")}
                         </Button>
                       </div>
                     </div>
                     <div className="grid grid-cols-2 gap-2 text-sm text-muted-foreground">
                       <div key={`doc-type-${doc.id}`}>
-                        <span className="font-medium">Type:</span> {getDocumentTypeLabel(doc)}
+                        <span className="font-medium">{t("type")}:</span> {getDocumentTypeLabel(doc, t)}
                       </div>
                       <div key={`doc-version-${doc.id}`}>
-                        <span className="font-medium">Version:</span> {doc.version || "1.0"}
+                        <span className="font-medium">{t("version")}:</span> {doc.version || "1.0"}
                       </div>
                       <div key={`doc-upload-date-${doc.id}`}>
-                        <span className="font-medium">Upload Date:</span> {doc.uploadedAt ? new Date(doc.uploadedAt).toLocaleDateString() : "N/A"}
+                        <span className="font-medium">{t("uploadDate")}:</span> {doc.uploadedAt ? new Date(doc.uploadedAt).toLocaleDateString() : t("notAvailable")}
                       </div>
                       {doc.rejection_reason && (
                         <div key={`doc-rejection-reason-${doc.id}`}>
-                          <span className="font-medium">Rejection Reason:</span> {doc.rejection_reason}
+                          <span className="font-medium">{t("rejectionReason")}:</span> {doc.rejection_reason}
                         </div>
                       )}
                     </div>
                     
                     {doc.id === reuploadDocumentId && (
                       <div className="mt-4 pt-4 border-t">
-                        <Label htmlFor={`document-${doc.id}`} className="text-sm font-medium">Re-upload Document</Label>
+                        <Label htmlFor={`document-${doc.id}`} className="text-sm font-medium">{t("reuploadDocument")}</Label>
                         <div className="flex items-center space-x-2 mt-2">
                           <Input
                             id={`document-${doc.id}`}
@@ -777,7 +778,7 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
                           />
                           <Button size="sm" disabled={isUploading}>
                             <Upload className="h-4 w-4 mr-2" />
-                            {isUploading ? "Uploading..." : "Upload"}
+                            {isUploading ? t("uploading") : t("upload")}
                           </Button>
                         </div>
                       </div>
@@ -790,10 +791,10 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
           
           <div className="flex justify-end space-x-2">
             <Button variant="outline" asChild>
-              <Link href="/dashboard/products">Cancel</Link>
+              <Link href="/dashboard/products">{t("cancel")}</Link>
             </Button>
             <Button onClick={handleSaveChanges} disabled={isSaving}>
-              {isSaving ? "Saving..." : "Save Changes"}
+              {isSaving ? t("saving") : t("saveChanges")}
             </Button>
           </div>
         </div>
@@ -804,18 +805,18 @@ export function ProductEdit({ productId, reuploadDocumentId }: ProductEditProps)
     <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete Document</AlertDialogTitle>
+          <AlertDialogTitle>{t("deleteDocument")}</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to delete &quot;{documentToDelete?.name}&quot;? This action cannot be undone.
+            {t("deleteDocumentConfirmation", { name: documentToDelete?.name || "" })}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
           <AlertDialogAction
             onClick={confirmDeleteDocument}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
-            Delete
+            {t("delete")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/components/dashboard/products/product-list.tsx
+++ b/components/dashboard/products/product-list.tsx
@@ -68,6 +68,26 @@ interface ProductListProps {
   };
 }
 
+// Helper function to get status label with translation
+const getStatusLabel = (status: string, t: any) => {
+  switch (status) {
+    case "DELETED":
+      return t("productManagement.status.rejected", { defaultValue: "Reddedildi" });
+    case "NEW":
+      return t("productManagement.status.pending", { defaultValue: "Beklemede" });
+    case "PENDING":
+      return t("productManagement.status.pending", { defaultValue: "Beklemede" });
+    case "REJECTED":
+      return t("productManagement.status.rejected", { defaultValue: "Reddedildi" });
+    case "APPROVED":
+      return t("productManagement.status.approved", { defaultValue: "Onaylandı" });
+    case "ARCHIVED":
+      return t("productManagement.status.archived", { defaultValue: "Arşivlendi" });
+    default:
+      return t("productManagement.status.pending", { defaultValue: "Beklemede" });
+  }
+};
+
 export function ProductList({ products, isLoading, isViewingManufacturer }: ProductListProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -250,7 +270,7 @@ export function ProductList({ products, isLoading, isViewingManufacturer }: Prod
                           ))}
                           {product.key_features && product.key_features.length > 3 && (
                             <Badge variant="secondary" className="text-xs">
-                              +{product.key_features.length - 3} more
+                              +{product.key_features.length - 3} {t("productManagement.list.more")}
                             </Badge>
                           )}
                         </div>
@@ -272,7 +292,7 @@ export function ProductList({ products, isLoading, isViewingManufacturer }: Prod
                             : "secondary"
                         }
                       >
-                        {status === "DELETED" ? "REDDEDİLDİ" : status === "NEW" ? "PENDING" : status === "REJECTED" ? "REJECTED" : status || "PENDING"}
+                        {getStatusLabel(status || "", t)}
                       </Badge>
                     </TableCell>
                     <TableCell>

--- a/components/dashboard/recent-activities.tsx
+++ b/components/dashboard/recent-activities.tsx
@@ -87,7 +87,7 @@ export function RecentActivities() {
               </p>
             </div>
             <div className="px-3 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-600 whitespace-nowrap">
-              {activity.status}
+              {t("status." + activity.status.toLowerCase())}
             </div>
           </motion.div>
         ))}


### PR DESCRIPTION
## 🔧 Fix Document Display and Add i18n Support

### Summary
Fixes document visibility issues in settings and adds internationalization support for document/certification types.

### Fixed Issues
- ✅ **Documents not displaying**: Fixed document list showing "Unnamed Document" instead of proper names
- ✅ **Document types hardcoded**: Replaced Turkish hardcoded strings with i18n translation keys
- ✅ **Download functionality**: Improved file download behavior

### Changes
- Fixed document name mapping in CompanyDocumentService
- Added i18n support for document and certification types  
- Enhanced error handling with Alert components
- Improved download functionality with proper file naming

### Languages Supported
- 🇹🇷 Turkish
- 🇬🇧 English

Now document types display correctly in both languages instead of raw keys like `trade_registry_gazette`.